### PR TITLE
fix cli in docs

### DIFF
--- a/website/docs/tutorial/quickstart/createPlugin.md
+++ b/website/docs/tutorial/quickstart/createPlugin.md
@@ -7,7 +7,7 @@ sidebar_position: 2
 We can quickly create a new plugin via `cli`.
 
 ```bash
-npx ministar createPlugin
+npx mini-star createPlugin
 ```
 
 `mini-star` will ask some questions through an interactive terminal program to finally create a plugin.
@@ -37,9 +37,9 @@ In order for the plugin to be loaded correctly, don't forget to use ministar to 
 You can also modify the output by modifying [outDir](../guide/ministarrc#outdir) in the configuration file.
 
 ```bash
-npx ministar buildPlugin test
+npx mini-star buildPlugin test
 
 # or
 
-npx ministar buildPlugin all
+npx mini-star buildPlugin all
 ```

--- a/website/docs/tutorial/quickstart/install.md
+++ b/website/docs/tutorial/quickstart/install.md
@@ -15,7 +15,7 @@ mini-star consists of three parts: `runtime`, `bundler` and `cli`
 Let's check if the `cli` of `mini-star` is working properly.
 
 ```bash
-npx ministar --help
+npx mini-star --help
 ```
 
 Let us quickly go to [Next Step](./createPlugin).

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/tutorial/quickstart/createPlugin.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/tutorial/quickstart/createPlugin.md
@@ -7,7 +7,7 @@ sidebar_position: 2
 我们可以通过`cli`快速创建一个新的插件。
 
 ```bash
-npx ministar createPlugin
+npx mini-star createPlugin
 ```
 
 `mini-star` 会通过一个交互式终端程序询问一些问题, 以最后创建一个插件。
@@ -37,9 +37,9 @@ npx ministar createPlugin
 你也可以通过修改配置文件的 [outDir](../guide/ministarrc#outdir) 来修改输出。
 
 ```bash
-npx ministar buildPlugin test
+npx mini-star buildPlugin test
 
 # or
 
-npx ministar buildPlugin all
+npx mini-star buildPlugin all
 ```

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/tutorial/quickstart/install.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/tutorial/quickstart/install.md
@@ -15,7 +15,7 @@ mini-star 由三个部分组成: `runtime`, `bundler` 和 `cli`
 我们来检查一下 `mini-star` 的`cli`是否正常工作。
 
 ```bash
-npx ministar --help
+npx mini-star --help
 ```
 
 让我们快速进入[下一步](./createPlugin)。


### PR DESCRIPTION
修复文档命令行，现在用npx miniStar是不行的，Registry找不到。 mini-start才可以。

<!--This is a translation content dividing line, the content below is generated by machine, please do not modify the content below-->
---
Repair the command line of the document, now it is not possible to use npx miniStar, and the Registry cannot find it. Only mini-start is available.
